### PR TITLE
Add logging and normalize frontend URL in SecurityConfig

### DIFF
--- a/backend/src/main/java/org/bea/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/org/bea/backend/security/SecurityConfig.java
@@ -2,6 +2,8 @@ package org.bea.backend.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -15,10 +17,21 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final String frontendUrl;
+    private static final Logger log = LoggerFactory.getLogger(SecurityConfig.class);
 
+    private final String frontendUrl;
     public SecurityConfig(@Value("${frontend.url:${FRONTEND_URL:http://localhost:5173}}") String frontendUrl) {
-        this.frontendUrl = frontendUrl;
+        String value = frontendUrl == null ? "" : frontendUrl.trim();
+        if (value.isEmpty()) {
+            log.warn("frontend.url / FRONTEND_URL is empty - falling back to http://localhost:5173");
+            value = "http://localhost:5173";
+        }
+        if (!value.startsWith("http://") && !value.startsWith("https://")) {
+            log.warn("frontend.url does not contain scheme (http/https): '{}'. Prefixing with 'https://'.", value);
+            value = "https://" + value;
+        }
+        this.frontendUrl = value;
+        log.info("Configured frontendUrl={}", this.frontendUrl);
     }
 
     @Bean


### PR DESCRIPTION
Add SLF4J logging to SecurityConfig to report which frontend URL is used at startup.
Normalize the frontend.url/FRONTEND_URL value: fall back to http://localhost:5173 when empty and prefix missing scheme with https://.
Purpose: ensure defaultSuccessUrl/logout redirect use an absolute URL (avoid relative redirects / 500 errors) and make misconfiguration visible in logs.