### PR TITLE
Use logoutSuccessHandler to externally redirect to frontend + log redirect

### DIFF
--- a/backend/src/main/java/org/bea/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/org/bea/backend/security/SecurityConfig.java
@@ -83,7 +83,10 @@ public class SecurityConfig {
                     // logoutUrl erwartet den lokalen Pfad, nicht die Frontend-URL.
                     // Die Frontend-URL wird aus der Konfiguration / Umgebung bezogen.
                     .logoutUrl("/logout")
-                    .logoutSuccessUrl(frontendUrl + "/recipe")
+                    .logoutSuccessHandler((request, response, authentication) -> {
+                        log.info("Logout success - redirecting to {}", frontendUrl + "/recipe");
+                        response.sendRedirect(frontendUrl + "/recipe");
+                    })
                     .invalidateHttpSession(true)
                     .clearAuthentication(true)
                     .deleteCookies("JSESSIONID")


### PR DESCRIPTION
Replace logoutSuccessUrl(frontendUrl + "/recipe") with an explicit logoutSuccessHandler in SecurityConfig to perform a browser redirect to the configured frontend URL (frontendUrl + "/recipe").
Add an INFO log entry on logout to record the redirect target.
Keep logoutUrl("/logout") and session invalidation/cookie clearing behaviour unchanged.
Reason: ensures the redirect goes to the external SPA domain (avoids internal/static-resource interpretation) and makes logout redirects observable in logs.